### PR TITLE
:seedling: Initialize ClimSim Burn model

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,18 @@ Compile the project (including all dependencies) in dev mode.
 
 ### Running the model
 
-TODO
+The neural network model can be ran by calling `src/main.rs` like so:
+
+    cargo run --release
+
+By default, the model will be trained using the `Wgpu`
+[backend](https://burn.dev/book/basic-workflow/backend.html). The training should show
+up as a Terminal User Interface (TUI) dashboard:
+
+![ClimSim Burn model training progression visualized on a Terminal User Interface](https://github.com/weiji14/climsimburn/assets/23487320/99d027f6-5f76-4d56-bf07-5d2912c25baf)
+
+Logs will be saved to `/tmp/experiment.log` by default. Hyperparameters can be adjusted
+by modifying the default values in the `TrainingConfig` struct in `src/training.rs`.
 
 
 ## References

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,126 @@
+// https://burn.dev/book/basic-workflow/data.html
+// https://github.com/tracel-ai/burn/blob/v0.13.2/crates/burn-dataset/src/vision/mnist.rs
+use std::fs::File;
+use std::io::Seek;
+use std::sync::{Arc, RwLock};
+
+use arrow::array::Float64Array;
+use arrow::error::{ArrowError, Result as ArrowResult};
+use arrow_csv::reader::{Format, Reader, ReaderBuilder};
+use burn::data::dataloader::batcher::Batcher;
+use burn::data::dataset::Dataset;
+use burn::prelude::{Backend, Tensor};
+
+#[derive(Debug, Clone)]
+pub(crate) struct ClimSimItem {
+    /// Input as 1D array of floats.
+    pub input: f64, //[[f64; WIDTH]; HEIGHT],
+    /// Target value of climate variable.
+    pub target: f64,
+}
+
+/// Reading ClimSim data from a CSV file into Arrow float arrays.
+pub struct ClimSimDataset {
+    dataset: RwLock<Reader<File>>,
+}
+
+impl ClimSimDataset {
+    pub fn new() -> ArrowResult<Self> {
+        let mut file =
+            File::open("data/train.csv").map_err(|err| ArrowError::CsvError(err.to_string()))?;
+
+        // Infer schema automatically
+        let format = Format::default().with_header(true);
+        let (schema, _) = format.infer_schema(&mut file, Some(10))?;
+        file.rewind().unwrap();
+        // println!("Schema of csv file {}", schema);
+
+        let csv_reader = ReaderBuilder::new(Arc::new(schema))
+            .with_header(true)
+            .with_batch_size(1)
+            .build(file)?;
+
+        let dataset = Self {
+            dataset: RwLock::new(csv_reader),
+        };
+
+        Ok(dataset)
+    }
+}
+
+impl Dataset<ClimSimItem> for ClimSimDataset {
+    fn get(&self, index: usize) -> Option<ClimSimItem> {
+        // let item = self.dataset.nth(index);
+        let mut rw_access = self.dataset.write().unwrap();
+        let item = rw_access.nth(index);
+        drop(rw_access);
+        match item {
+            Some(r) => {
+                let rec_batch = r.unwrap();
+
+                let input: f64 = rec_batch
+                    .column_by_name("state_u_0") // TODO get more climate variables
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Float64Array>()
+                    .expect("Failed to downcast")
+                    .value(0);
+
+                let target: f64 = rec_batch
+                    .column_by_name("ptend_u_0") // TODO get more climate variables
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Float64Array>()
+                    .expect("Failed to downcast")
+                    .value(0);
+
+                Some(ClimSimItem { input, target })
+            }
+            None => None,
+        }
+    }
+    fn len(&self) -> usize {
+        // let mut rw_access = self.dataset.write().unwrap();
+        // let row_count = rw_access.count();
+        // drop(rw_access);
+        // row_count
+        256
+    }
+}
+
+/// Map ClimSim dataset items into batched tensors.
+#[derive(Clone)]
+pub struct ClimSimBatcher<B: Backend> {
+    device: B::Device,
+}
+
+impl<B: Backend> ClimSimBatcher<B> {
+    pub fn new(device: B::Device) -> Self {
+        Self { device }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ClimSimBatch<B: Backend> {
+    pub inputs: Tensor<B, 2>,
+    pub targets: Tensor<B, 2>,
+}
+
+impl<B: Backend> Batcher<ClimSimItem, ClimSimBatch<B>> for ClimSimBatcher<B> {
+    fn batch(&self, items: Vec<ClimSimItem>) -> ClimSimBatch<B> {
+        let inputs: Vec<_> = items
+            .iter()
+            .map(|item| Tensor::<B, 2>::from_floats([[item.input as f32]], &self.device))
+            .collect();
+
+        let targets: Vec<_> = items
+            .iter()
+            .map(|item| Tensor::<B, 2>::from_floats([[item.target as f32]], &self.device))
+            .collect();
+
+        let inputs = Tensor::cat(inputs, 0);
+        let targets = Tensor::cat(targets, 0);
+
+        ClimSimBatch { inputs, targets }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod data;
+pub mod model;
+pub mod training;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
     let device = burn::backend::wgpu::WgpuDevice::BestAvailable;
     crate::training::train::<MyAutodiffBackend>(
         "/tmp",
-        crate::training::TrainingConfig::new(ClimSimModelConfig::new(1, 256), AdamConfig::new()),
+        crate::training::TrainingConfig::new(ClimSimModelConfig::new(256), AdamConfig::new()),
         device,
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,22 @@
+// https://burn.dev/book/basic-workflow/backend.html
+mod data;
+mod model;
+mod training;
+
+use burn::backend::wgpu::AutoGraphicsApi;
+use burn::backend::{Autodiff, Wgpu};
+use burn::optim::AdamConfig;
+
+use crate::model::ClimSimModelConfig;
+
+fn main() {
+    type MyBackend = Wgpu<AutoGraphicsApi, f32, i32>;
+    type MyAutodiffBackend = Autodiff<MyBackend>;
+
+    let device = burn::backend::wgpu::WgpuDevice::BestAvailable;
+    crate::training::train::<MyAutodiffBackend>(
+        "/tmp",
+        crate::training::TrainingConfig::new(ClimSimModelConfig::new(1, 256), AdamConfig::new()),
+        device,
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
     let device = burn::backend::wgpu::WgpuDevice::BestAvailable;
     crate::training::train::<MyAutodiffBackend>(
         "/tmp",
-        crate::training::TrainingConfig::new(ClimSimModelConfig::new(256), AdamConfig::new()),
+        crate::training::TrainingConfig::new(ClimSimModelConfig::new(1024), AdamConfig::new()),
         device,
     );
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,0 +1,39 @@
+// https://burn.dev/book/basic-workflow/model.html
+use burn::nn::{Linear, LinearConfig, Relu};
+use burn::prelude::{Backend, Config, Module, Tensor};
+
+#[derive(Module, Debug)]
+pub struct ClimSimModel<B: Backend> {
+    linear1: Linear<B>,
+    linear2: Linear<B>,
+    activation: Relu,
+}
+
+#[derive(Config, Debug)]
+pub struct ClimSimModelConfig {
+    num_classes: usize,
+    hidden_size: usize,
+}
+
+impl ClimSimModelConfig {
+    // Returns the initialized model
+    pub fn init<B: Backend>(&self, device: &B::Device) -> ClimSimModel<B> {
+        ClimSimModel {
+            linear1: LinearConfig::new(1, self.hidden_size).init(device),
+            linear2: LinearConfig::new(self.hidden_size, self.num_classes).init(device),
+            activation: Relu::new(),
+        }
+    }
+}
+
+impl<B: Backend> ClimSimModel<B> {
+    /// # Shapes
+    ///   - Images [batch_size, climate_variables]
+    ///   - Output [batch_size, climate_variables]
+    pub fn forward(&self, inputs: Tensor<B, 2>) -> Tensor<B, 2> {
+        let x = self.linear1.forward(inputs);
+        let x = self.activation.forward(x);
+
+        self.linear2.forward(x) // [batch_size, num_classes]
+    }
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,12 +1,15 @@
 // https://burn.dev/book/basic-workflow/model.html
-use burn::nn::{Linear, LinearConfig, Relu};
+use burn::nn::{LayerNorm, LayerNormConfig, Linear, LinearConfig};
 use burn::prelude::{Backend, Config, Module, Tensor};
+use burn::tensor::activation::relu;
 
 #[derive(Module, Debug)]
 pub struct ClimSimModel<B: Backend> {
     linear1: Linear<B>,
     linear2: Linear<B>,
-    activation: Relu,
+    linear3: Linear<B>,
+    norm1: LayerNorm<B>,
+    norm2: LayerNorm<B>,
 }
 
 #[derive(Config, Debug)]
@@ -19,8 +22,10 @@ impl ClimSimModelConfig {
     pub fn init<B: Backend>(&self, device: &B::Device) -> ClimSimModel<B> {
         ClimSimModel {
             linear1: LinearConfig::new(556, self.hidden_size).init(device),
-            linear2: LinearConfig::new(self.hidden_size, 368).init(device),
-            activation: Relu::new(),
+            linear2: LinearConfig::new(self.hidden_size, self.hidden_size / 2).init(device),
+            linear3: LinearConfig::new(self.hidden_size / 2, 368).init(device),
+            norm1: LayerNormConfig::new(self.hidden_size).init(device),
+            norm2: LayerNormConfig::new(self.hidden_size / 2).init(device),
         }
     }
 }
@@ -31,8 +36,13 @@ impl<B: Backend> ClimSimModel<B> {
     ///   - Output [batch_size, climate_variables]
     pub fn forward(&self, inputs: Tensor<B, 2>) -> Tensor<B, 2> {
         let x = self.linear1.forward(inputs);
-        let x = self.activation.forward(x);
+        let x = self.norm1.forward(x);
+        let x = relu(x);
 
-        self.linear2.forward(x) // [batch_size, num_classes]
+        let x = self.linear2.forward(x);
+        let x = self.norm2.forward(x);
+        let x = relu(x);
+
+        self.linear3.forward(x) // [batch_size, num_classes]
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -11,7 +11,6 @@ pub struct ClimSimModel<B: Backend> {
 
 #[derive(Config, Debug)]
 pub struct ClimSimModelConfig {
-    num_classes: usize,
     hidden_size: usize,
 }
 
@@ -19,8 +18,8 @@ impl ClimSimModelConfig {
     // Returns the initialized model
     pub fn init<B: Backend>(&self, device: &B::Device) -> ClimSimModel<B> {
         ClimSimModel {
-            linear1: LinearConfig::new(1, self.hidden_size).init(device),
-            linear2: LinearConfig::new(self.hidden_size, self.num_classes).init(device),
+            linear1: LinearConfig::new(556, self.hidden_size).init(device),
+            linear2: LinearConfig::new(self.hidden_size, 368).init(device),
             activation: Relu::new(),
         }
     }

--- a/src/training.rs
+++ b/src/training.rs
@@ -77,7 +77,7 @@ pub struct TrainingConfig {
     #[config(default = 42)]
     pub seed: u64,
 
-    #[config(default = 1.0e-4)]
+    #[config(default = 1.0e-3)]
     pub learning_rate: f64,
 }
 

--- a/src/training.rs
+++ b/src/training.rs
@@ -1,0 +1,136 @@
+use burn::data::dataloader::DataLoaderBuilder;
+use burn::nn::loss::{MseLoss, Reduction};
+use burn::optim::AdamConfig;
+use burn::prelude::{Backend, Config, Module, Tensor};
+use burn::record::CompactRecorder;
+use burn::tensor::backend::AutodiffBackend;
+use burn::train::metric::{Adaptor, CpuUse, LossInput, LossMetric};
+use burn::train::{LearnerBuilder, TrainOutput, TrainStep, ValidStep};
+use derive_new::new;
+
+use crate::data::{ClimSimBatch, ClimSimBatcher, ClimSimDataset};
+use crate::model::{ClimSimModel, ClimSimModelConfig};
+
+/// Regression output adapted for multiple climate variables in the ClimSim dataset..
+#[derive(new)]
+pub struct ClimSimRegressionOutput<B: Backend> {
+    /// The loss.
+    pub loss: Tensor<B, 1>,
+    /// The output [batch_size, num_classes]
+    pub output: Tensor<B, 2>,
+    /// The targets [batch_size, num_classes]
+    pub targets: Tensor<B, 2>,
+}
+
+impl<B: Backend> Adaptor<LossInput<B>> for ClimSimRegressionOutput<B> {
+    fn adapt(&self) -> LossInput<B> {
+        LossInput::new(self.loss.clone())
+    }
+}
+
+/// Forward pass to get loss value
+impl<B: Backend> ClimSimModel<B> {
+    pub fn forward_regression(
+        &self,
+        inputs: Tensor<B, 2>,
+        targets: Tensor<B, 2>,
+    ) -> ClimSimRegressionOutput<B> {
+        let output = self.forward(inputs);
+        let loss = MseLoss::new().forward(output.clone(), targets.clone(), Reduction::Mean);
+
+        ClimSimRegressionOutput::new(loss, output, targets)
+    }
+}
+
+/// Training step
+impl<B: AutodiffBackend> TrainStep<ClimSimBatch<B>, ClimSimRegressionOutput<B>>
+    for ClimSimModel<B>
+{
+    fn step(&self, batch: ClimSimBatch<B>) -> TrainOutput<ClimSimRegressionOutput<B>> {
+        let item = self.forward_regression(batch.inputs, batch.targets);
+        TrainOutput::new(self, item.loss.backward(), item)
+    }
+}
+
+/// Validation step
+impl<B: Backend> ValidStep<ClimSimBatch<B>, ClimSimRegressionOutput<B>> for ClimSimModel<B> {
+    fn step(&self, batch: ClimSimBatch<B>) -> ClimSimRegressionOutput<B> {
+        self.forward_regression(batch.inputs, batch.targets)
+    }
+}
+
+/// Hyperparameters for the ClimSimModel
+#[derive(Config)]
+pub struct TrainingConfig {
+    pub model: ClimSimModelConfig,
+    pub optimizer: AdamConfig,
+
+    #[config(default = 100)]
+    pub num_epochs: usize,
+
+    #[config(default = 32)]
+    pub batch_size: usize,
+
+    #[config(default = 4)]
+    pub num_workers: usize,
+
+    #[config(default = 42)]
+    pub seed: u64,
+
+    #[config(default = 1.0e-4)]
+    pub learning_rate: f64,
+}
+
+fn create_artifact_dir(artifact_dir: &str) {
+    // Remove existing artifacts before to get an accurate learner summary
+    std::fs::remove_dir_all(artifact_dir).ok();
+    std::fs::create_dir_all(artifact_dir).ok();
+}
+
+pub fn train<B: AutodiffBackend>(artifact_dir: &str, config: TrainingConfig, device: B::Device) {
+    create_artifact_dir(artifact_dir);
+    config
+        .save(format!("{artifact_dir}/config.json"))
+        .expect("Config should be saved successfully");
+
+    B::seed(config.seed);
+
+    // Setup dataloaders
+    let batcher_train = ClimSimBatcher::<B>::new(device.clone());
+    let batcher_valid = ClimSimBatcher::<B::InnerBackend>::new(device.clone());
+
+    let dataloader_train = DataLoaderBuilder::new(batcher_train)
+        .batch_size(config.batch_size)
+        .shuffle(config.seed)
+        .num_workers(config.num_workers)
+        .build(ClimSimDataset::new().unwrap());
+
+    let dataloader_valid = DataLoaderBuilder::new(batcher_valid)
+        .batch_size(config.batch_size)
+        .shuffle(config.seed)
+        .num_workers(config.num_workers)
+        .build(ClimSimDataset::new().unwrap());
+
+    // Setup learner
+    let learner = LearnerBuilder::new(artifact_dir)
+        .metric_train_numeric(LossMetric::new())
+        .metric_valid_numeric(LossMetric::new())
+        .metric_train_numeric(CpuUse::new())
+        .metric_valid_numeric(CpuUse::new())
+        .with_file_checkpointer(CompactRecorder::new())
+        .devices(vec![device.clone()])
+        .num_epochs(config.num_epochs)
+        .summary()
+        .build(
+            config.model.init::<B>(&device),
+            config.optimizer.init(),
+            config.learning_rate,
+        );
+
+    // Start training
+    let model_trained = learner.fit(dataloader_train, dataloader_valid);
+
+    model_trained
+        .save_file(format!("{artifact_dir}/model"), &CompactRecorder::new())
+        .expect("Trained model should be saved successfully");
+}


### PR DESCRIPTION
Implement a deep learning model using [Burn](https://burn.dev) :fire: to train on the ClimSim dataset! Data is read from CSV files using [`arrow-csv`](https://docs.rs/arrow-csv/51.0.0/arrow_csv/index.html), and passed into a simple feedforward neural network with 3 linear layers.

Run using:

```
cargo run --release
```

![ClimSim Burn model training progression visualized on a Terminal User Interface](https://github.com/weiji14/climsimburn/assets/23487320/99d027f6-5f76-4d56-bf07-5d2912c25baf)

TODO:
- [x] Initial rough implementation
- [x] Refactor dataset to get more (if not all) columns from ClimSim train.csv file
- [x] Refactor model to be slightly more complex than 2 linear layers

References:
- https://burn.dev/book/basic-workflow/index.html
- https://github.com/tracel-ai/burn/blob/v0.13.2/crates/burn-dataset/src/vision/mnist.rs
- https://github.com/tracel-ai/burn/blob/main/examples/guide/src/training.rs
- https://www.kaggle.com/competitions/leap-atmospheric-physics-ai-climsim/overview
- https://docs.rs/arrow-array/51.0.0/arrow_array/index.html#downcasting-an-array