### PR TITLE
:card_file_box: Implement train/test split logic and store index string column

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,6 +799,7 @@ dependencies = [
  "arrow-csv",
  "burn",
  "derive-new",
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ arrow = "51.0.0"
 arrow-csv = "51.0.0"
 burn = { version = "0.13.2", features = ["train", "wgpu"] }
 derive-new = "0.6.0"
+num-traits = "0.2.19"

--- a/src/training.rs
+++ b/src/training.rs
@@ -8,7 +8,7 @@ use burn::train::metric::{Adaptor, CpuUse, LossInput, LossMetric};
 use burn::train::{LearnerBuilder, TrainOutput, TrainStep, ValidStep};
 use derive_new::new;
 
-use crate::data::{ClimSimBatch, ClimSimBatcher, ClimSimDataset};
+use crate::data::{ClimSimBatch, ClimSimBatcher, ClimSimDataSplit, ClimSimDataset};
 use crate::model::{ClimSimModel, ClimSimModelConfig};
 
 /// Regression output adapted for multiple climate variables in the ClimSim dataset..
@@ -103,13 +103,13 @@ pub fn train<B: AutodiffBackend>(artifact_dir: &str, config: TrainingConfig, dev
         .batch_size(config.batch_size)
         .shuffle(config.seed)
         .num_workers(config.num_workers)
-        .build(ClimSimDataset::new().unwrap());
+        .build(ClimSimDataset::new(ClimSimDataSplit::Train).unwrap());
 
     let dataloader_valid = DataLoaderBuilder::new(batcher_valid)
         .batch_size(config.batch_size)
         .shuffle(config.seed)
         .num_workers(config.num_workers)
-        .build(ClimSimDataset::new().unwrap());
+        .build(ClimSimDataset::new(ClimSimDataSplit::Valid).unwrap());
 
     // Setup learner
     let learner = LearnerBuilder::new(artifact_dir)


### PR DESCRIPTION
To enable a smoother implementation of the inference script later, this PR adds some logic to `src/data.rs` to handle train/validation/test splits a bit more properly, and also stores the index string column that was originally left out in #1.

TODO:
- [x] Create `ClimSimDataSplit` enum to handle train/valid/test split logic
- [x] Add an `idx` field to `ClimSimItem` struct and an `indexes` field to the `ClimSimBatch` struct to store index strings like `train_0` or `test_169651`