### PR TITLE
:chart_with_upwards_trend: Change loss function from MSE to Huber

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -54,8 +54,10 @@ impl ClimSimDataset {
             .with_batch_size(1); // read one row at a time
 
         let csv_reader_subset = match split {
-            ClimSimDataSplit::Train => csv_reader.with_bounds(0, 256000).build(file)?,
-            ClimSimDataSplit::Valid => csv_reader.with_bounds(256000, 512000).build(file)?,
+            // train.csv has 10_091_520 rows
+            ClimSimDataSplit::Train => csv_reader.with_bounds(0, 10_000_000).build(file)?,
+            ClimSimDataSplit::Valid => csv_reader.with_bounds(10000000, 10_091_520).build(file)?,
+            // test.csv has 625_000 rows
             ClimSimDataSplit::Test => csv_reader.build(file)?, // read all 625000 rows in test.csv
         };
 
@@ -116,8 +118,9 @@ impl Dataset<ClimSimItem> for ClimSimDataset {
         // drop(rw_access);
         // row_count
         match self.split {
-            ClimSimDataSplit::Train | ClimSimDataSplit::Valid => 256, // 256000
-            ClimSimDataSplit::Test => 625000,
+            ClimSimDataSplit::Train => 512_000,
+            ClimSimDataSplit::Valid => 12_000,
+            ClimSimDataSplit::Test => 625_000,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
     type MyBackend = Wgpu<AutoGraphicsApi, f32, i32>;
     type MyAutodiffBackend = Autodiff<MyBackend>;
 
-    let artifact_dir = "artifacts/v00";
+    let artifact_dir = "artifacts/v02";
     let device = burn::backend::wgpu::WgpuDevice::BestAvailable;
 
     // Train model

--- a/src/training.rs
+++ b/src/training.rs
@@ -1,5 +1,4 @@
 use burn::data::dataloader::DataLoaderBuilder;
-use burn::nn::loss::{MseLoss, Reduction};
 use burn::optim::AdamConfig;
 use burn::prelude::{Backend, Config, Module, Tensor};
 use burn::record::CompactRecorder;
@@ -16,9 +15,9 @@ use crate::model::{ClimSimModel, ClimSimModelConfig};
 pub struct ClimSimRegressionOutput<B: Backend> {
     /// The loss.
     pub loss: Tensor<B, 1>,
-    /// The output [batch_size, num_classes]
-    pub output: Tensor<B, 2>,
-    /// The targets [batch_size, num_classes]
+    /// The predicted outputs [batch_size, num_classes]
+    pub outputs: Tensor<B, 2>,
+    /// The groundtruth targets [batch_size, num_classes]
     pub targets: Tensor<B, 2>,
 }
 
@@ -35,10 +34,10 @@ impl<B: Backend> ClimSimModel<B> {
         inputs: Tensor<B, 2>,
         targets: Tensor<B, 2>,
     ) -> ClimSimRegressionOutput<B> {
-        let output = self.forward(inputs);
-        let loss = MseLoss::new().forward(output.clone(), targets.clone(), Reduction::Mean);
+        let outputs = self.forward(inputs);
+        let loss = self.loss(outputs.clone(), targets.clone());
 
-        ClimSimRegressionOutput::new(loss, output, targets)
+        ClimSimRegressionOutput::new(loss, outputs, targets)
     }
 }
 

--- a/src/training.rs
+++ b/src/training.rs
@@ -67,7 +67,7 @@ pub struct TrainingConfig {
     #[config(default = 20)]
     pub num_epochs: usize,
 
-    #[config(default = 32)]
+    #[config(default = 512)]
     pub batch_size: usize,
 
     #[config(default = 4)]


### PR DESCRIPTION
Changing the loss function from MeanSquaredError Loss to Huber Loss! Interestingly, this speeds up training a lot, maybe because it's running on the WebGPU device now?

Notes:
- Using a delta value of 1.0
- Using Reduction::Sum instead of the Reduction:Mean default

Also increased batch_size from 32 to 512 to take advantage of the speed up, and modified the train/validation splits to include all 10091520 rows of train.csv now!